### PR TITLE
Fix for symfony 4/5 compatibility

### DIFF
--- a/Controller/ChangePasswordController.php
+++ b/Controller/ChangePasswordController.php
@@ -59,7 +59,7 @@ class ChangePasswordController extends AbstractController
         }
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::CHANGE_PASSWORD_INITIALIZE);
+        $this->eventDispatcher->dispatch($event);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -72,7 +72,7 @@ class ChangePasswordController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::CHANGE_PASSWORD_SUCCESS);
+            $this->eventDispatcher->dispatch($event);
 
             $this->userManager->updateUser($user);
 
@@ -81,7 +81,7 @@ class ChangePasswordController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::CHANGE_PASSWORD_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response));
 
             return $response;
         }

--- a/Controller/GroupController.php
+++ b/Controller/GroupController.php
@@ -82,7 +82,7 @@ class GroupController extends AbstractController
         $group = $this->findGroupBy('name', $groupName);
 
         $event = new GetResponseGroupEvent($group, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::GROUP_EDIT_INITIALIZE);
+        $this->eventDispatcher->dispatch($event);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -95,7 +95,7 @@ class GroupController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::GROUP_EDIT_SUCCESS);
+            $this->eventDispatcher->dispatch($event);
 
             $this->groupManager->updateGroup($group);
 
@@ -104,7 +104,7 @@ class GroupController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response), FOSUserEvents::GROUP_EDIT_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response));
 
             return $response;
         }
@@ -126,7 +126,7 @@ class GroupController extends AbstractController
     {
         $group = $this->groupManager->createGroup('');
 
-        $this->eventDispatcher->dispatch(new GroupEvent($group, $request), FOSUserEvents::GROUP_CREATE_INITIALIZE);
+        $this->eventDispatcher->dispatch(new GroupEvent($group, $request));
 
         $form = $this->formFactory->createForm();
         $form->setData($group);
@@ -135,7 +135,7 @@ class GroupController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::GROUP_CREATE_SUCCESS);
+            $this->eventDispatcher->dispatch($event);
 
             $this->groupManager->updateGroup($group);
 
@@ -144,7 +144,7 @@ class GroupController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response), FOSUserEvents::GROUP_CREATE_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response));
 
             return $response;
         }
@@ -169,7 +169,7 @@ class GroupController extends AbstractController
 
         $response = new RedirectResponse($this->generateUrl('fos_user_group_list'));
 
-        $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response), FOSUserEvents::GROUP_DELETE_COMPLETED);
+        $this->eventDispatcher->dispatch(new FilterGroupResponseEvent($group, $request, $response));
 
         return $response;
     }

--- a/Controller/ProfileController.php
+++ b/Controller/ProfileController.php
@@ -73,7 +73,7 @@ class ProfileController extends AbstractController
         }
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::PROFILE_EDIT_INITIALIZE);
+        $this->eventDispatcher->dispatch($event);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -86,7 +86,7 @@ class ProfileController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::PROFILE_EDIT_SUCCESS);
+            $this->eventDispatcher->dispatch($event);
 
             $this->userManager->updateUser($user);
 
@@ -95,7 +95,7 @@ class ProfileController extends AbstractController
                 $response = new RedirectResponse($url);
             }
 
-            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::PROFILE_EDIT_COMPLETED);
+            $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response));
 
             return $response;
         }

--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -59,7 +59,7 @@ class RegistrationController extends AbstractController
         $user->setEnabled(true);
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_INITIALIZE);
+        $this->eventDispatcher->dispatch($event);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -73,7 +73,7 @@ class RegistrationController extends AbstractController
         if ($form->isSubmitted()) {
             if ($form->isValid()) {
                 $event = new FormEvent($form, $request);
-                $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_SUCCESS);
+                $this->eventDispatcher->dispatch($event);
 
                 $this->userManager->updateUser($user);
 
@@ -82,13 +82,13 @@ class RegistrationController extends AbstractController
                     $response = new RedirectResponse($url);
                 }
 
-                $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::REGISTRATION_COMPLETED);
+                $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response));
 
                 return $response;
             }
 
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_FAILURE);
+            $this->eventDispatcher->dispatch($event);
 
             if (null !== $response = $event->getResponse()) {
                 return $response;
@@ -145,7 +145,7 @@ class RegistrationController extends AbstractController
         $user->setEnabled(true);
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::REGISTRATION_CONFIRM);
+        $this->eventDispatcher->dispatch($event);
 
         $userManager->updateUser($user);
 
@@ -154,7 +154,7 @@ class RegistrationController extends AbstractController
             $response = new RedirectResponse($url);
         }
 
-        $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response), FOSUserEvents::REGISTRATION_CONFIRMED);
+        $this->eventDispatcher->dispatch(new FilterUserResponseEvent($user, $request, $response));
 
         return $response;
     }

--- a/Controller/ResettingController.php
+++ b/Controller/ResettingController.php
@@ -85,7 +85,7 @@ class ResettingController extends AbstractController
         $user = $this->userManager->findUserByUsernameOrEmail($username);
 
         $event = new GetResponseNullableUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_SEND_EMAIL_INITIALIZE);
+        $this->eventDispatcher->dispatch($event);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -93,7 +93,7 @@ class ResettingController extends AbstractController
 
         if (null !== $user && !$user->isPasswordRequestNonExpired($this->retryTtl)) {
             $event = new GetResponseUserEvent($user, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_RESET_REQUEST);
+            $this->eventDispatcher->dispatch($event);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -104,7 +104,7 @@ class ResettingController extends AbstractController
             }
 
             $event = new GetResponseUserEvent($user, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_SEND_EMAIL_CONFIRM);
+            $this->eventDispatcher->dispatch($event);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -115,7 +115,7 @@ class ResettingController extends AbstractController
             $this->userManager->updateUser($user);
 
             $event = new GetResponseUserEvent($user, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_SEND_EMAIL_COMPLETED);
+            $this->eventDispatcher->dispatch($event);
 
             if (null !== $event->getResponse()) {
                 return $event->getResponse();
@@ -163,7 +163,7 @@ class ResettingController extends AbstractController
         }
 
         $event = new GetResponseUserEvent($user, $request);
-        $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_RESET_INITIALIZE);
+        $this->eventDispatcher->dispatch($event);
 
         if (null !== $event->getResponse()) {
             return $event->getResponse();
@@ -176,7 +176,7 @@ class ResettingController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $event = new FormEvent($form, $request);
-            $this->eventDispatcher->dispatch($event, FOSUserEvents::RESETTING_RESET_SUCCESS);
+            $this->eventDispatcher->dispatch($event);
 
             $this->userManager->updateUser($user);
 
@@ -186,8 +186,7 @@ class ResettingController extends AbstractController
             }
 
             $this->eventDispatcher->dispatch(
-                new FilterUserResponseEvent($user, $request, $response),
-                FOSUserEvents::RESETTING_RESET_COMPLETED
+                new FilterUserResponseEvent($user, $request, $response)
             );
 
             return $response;

--- a/EventListener/AuthenticationListener.php
+++ b/EventListener/AuthenticationListener.php
@@ -50,22 +50,20 @@ class AuthenticationListener implements EventSubscriberInterface
     {
         return array(
             FOSUserEvents::REGISTRATION_COMPLETED => 'authenticate',
-            FOSUserEvents::REGISTRATION_CONFIRMED => 'authenticate',
             FOSUserEvents::RESETTING_RESET_COMPLETED => 'authenticate',
         );
     }
 
     /**
      * @param FilterUserResponseEvent  $event
-     * @param string                   $eventName
      * @param EventDispatcherInterface $eventDispatcher
      */
-    public function authenticate(FilterUserResponseEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
+    public function authenticate(FilterUserResponseEvent $event, EventDispatcherInterface $eventDispatcher)
     {
         try {
             $this->loginManager->logInUser($this->firewallName, $event->getUser(), $event->getResponse());
 
-            $eventDispatcher->dispatch(FOSUserEvents::SECURITY_IMPLICIT_LOGIN, new UserEvent($event->getUser(), $event->getRequest()));
+            $eventDispatcher->dispatch(new UserEvent($event->getUser(), $event->getRequest()));
         } catch (AccountStatusException $ex) {
             // We simply do not authenticate users which do not pass the user
             // checker (not enabled, expired, etc.).

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -31,7 +31,7 @@ class Mailer implements MailerInterface
     protected $router;
 
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     protected $templating;
 

--- a/Tests/EventListener/AuthenticationListenerTest.php
+++ b/Tests/EventListener/AuthenticationListenerTest.php
@@ -50,6 +50,6 @@ class AuthenticationListenerTest extends TestCase
 
     public function testAuthenticate()
     {
-        $this->listener->authenticate($this->event, FOSUserEvents::REGISTRATION_COMPLETED, $this->eventDispatcher);
+        $this->listener->authenticate($this->event, $this->eventDispatcher);
     }
 }

--- a/Tests/Mailer/MailerTest.php
+++ b/Tests/Mailer/MailerTest.php
@@ -101,7 +101,7 @@ class MailerTest extends TestCase
 
     private function getTemplating()
     {
-        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')
+        $templating = $this->getMockBuilder('Twig\Environment')
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/Util/UserManipulator.php
+++ b/Util/UserManipulator.php
@@ -16,6 +16,7 @@ use FOS\UserBundle\FOSUserEvents;
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -79,7 +80,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch(FOSUserEvents::USER_CREATED, $event);
+        $this->dispatcher->dispatch($event);
 
         return $user;
     }
@@ -96,7 +97,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch(FOSUserEvents::USER_ACTIVATED, $event);
+        $this->dispatcher->dispatch($event);
     }
 
     /**
@@ -111,7 +112,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch(FOSUserEvents::USER_DEACTIVATED, $event);
+        $this->dispatcher->dispatch($event);
     }
 
     /**
@@ -127,7 +128,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch(FOSUserEvents::USER_PASSWORD_CHANGED, $event);
+        $this->dispatcher->dispatch($event);
     }
 
     /**
@@ -142,7 +143,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch(FOSUserEvents::USER_PROMOTED, $event);
+        $this->dispatcher->dispatch($event);
     }
 
     /**
@@ -157,7 +158,7 @@ class UserManipulator
         $this->userManager->updateUser($user);
 
         $event = new UserEvent($user, $this->getRequest());
-        $this->dispatcher->dispatch(FOSUserEvents::USER_DEMOTED, $event);
+        $this->dispatcher->dispatch($event);
     }
 
     /**


### PR DESCRIPTION
Fix mistake with event dispatching to prevent error like this:

`PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" must be an instance o
f Symfony\Component\EventDispatcher\Event, FOS\UserBundle\Event\UserEvent given. in E:\DEV\Cal\Cal\vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:154
Stack trace:
#0 E:\DEV\Cal\Cal\vendor\friendsofsymfony\user-bundle\Util\UserManipulator.php(82): Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(Object(FOS\UserBundle\Event\UserEvent)
, Object(FOS\UserBundle\Event\UserEvent))
#1 E:\DEV\Cal\Cal\vendor\friendsofsymfony\user-bundle\Command\CreateUserCommand.php(89): FOS\UserBundle\Util\UserManipulator->create('GothShoot', '67fa742172np', 'romuald.mocq@ya...', true, false)
#2 E:\DEV\Cal\Cal\vendor\symfony\console\Command\Command.php(255): FOS\UserBundle\Command\CreateUserCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Cons
ole\Output\ConsoleOutput))
#3 in E:\DEV\Cal\Cal\vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php on line 154`